### PR TITLE
fix(route): url parsing with ping3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,157 @@
 __pycache__/
 **/__pycache__/
+
+__pycache__# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask import Flask, request, jsonify, make_response
 from flask_cors import CORS
 
 from utils.ModelUtils import get_prediction
-from utils.URLUtils import get_description, get_domain, get_status
+from utils.URLUtils import get_description, get_domain, get_status, reformat_url, url_exists
 
 app = Flask(__name__)
 CORS(app)
@@ -14,6 +14,10 @@ def predict():
     try:
         data = request.get_json()
         url = data.get('url')
+        url=reformat_url(url)
+        if(url_exists(url)==False) :
+            return make_response(jsonify({"error": "The URL doesn't exist "}), 400)
+
         output=get_prediction(url)
         domain_name=get_domain(url)
         status=get_status(output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=1.3.3
 torch>=1.9.0
 torchvision>=0.10.0
 scikit-learn
+ping3>=4.0.4

--- a/utils/URLUtils.py
+++ b/utils/URLUtils.py
@@ -1,3 +1,4 @@
+from ping3 import ping
 from urllib.parse import urlparse
 from URLFeatureExtractor import URLFeatureExtractor
 
@@ -27,5 +28,19 @@ def get_description(output, url):
         return average
     else:
         return safe
+
+def reformat_url(url):
+    if not url.startswith('https://') and not url.startswith('http://'):
+        url = 'https://' + url
+    return url
+    
+def url_exists(url):
+    try:
+        host = url.split('//')[1].split('/')[0] 
+        result = ping(host, timeout=1) 
+        return result 
+    except Exception as e:
+        return False
+
 
 


### PR DESCRIPTION
# Description

- Over the backend, entering a solid url, which without attributes like `http://` or `www.` results in improper parsing of it.
- This has  been resolved, with a ping3 check of a URL, and adding to it with proper formatting 

e.g. let's say, the url is `accounts.google.com`, pinging it would result in a match , and we could add to this url with `https://` or `http://` assuming it's required for processing .

![image](https://github.com/V-SYNC-ON/ThatsPhishy-BE/assets/84082104/2767b49f-d9f5-4788-9d23-4087fc706b50)


